### PR TITLE
Fixed spelling error in config example for sql resource

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 Config.Locale = "en"
-Config.Mysql = 'ghmattisql' -- "ghmattisql", "msyql-async"
+Config.Mysql = 'ghmattisql' -- "ghmattisql", "mysql-async"
 Config.UseRayZone = false -- unrelease script https://github.com/renzuzu/renzu_rayzone
 Config.UsePopUI = true -- Create a Thread for checking playercoords and Use POPUI to Trigger Event, set this to false if using rayzone. Popui is originaly built in to RayZone -- DOWNLOAD https://github.com/renzuzu/renzu_popui
 Config.Quickpick = true -- if false system will create a garage shell and spawn every vehicle you preview


### PR DESCRIPTION
Fixed a spelling error on the config - Hopefully saves some headaches in future with people copy-pasting from the comment.